### PR TITLE
[main] Add support for privacy manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- (iOS): Support for Privacy Manifest
+
 ## 0.1.2
 
 - Bumped kotlin from 1.3.72 to 1.7.21

--- a/ios/Resources/PrivacyInfo.xcprivac
+++ b/ios/Resources/PrivacyInfo.xcprivac
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+				<string>E174.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
# Changes

Added support for privacy manifest.
The following APIs needed this support in this repository. 
- volumeAvailableCapacityForImportantUsageKey
- systemFreeSize
- systemSize